### PR TITLE
Add networking input argument to build-and-push-docker-image workflow

### DIFF
--- a/.github/workflows/build-and-push-docker-image.yml
+++ b/.github/workflows/build-and-push-docker-image.yml
@@ -63,6 +63,8 @@ jobs:
   
       - name: Install Docker Buildx
         uses: docker/setup-buildx-action@v3
+        with:
+          driver-opts: "network=${{ inputs.network }}"
 
       - name: Log in to the Container registry
         uses: docker/login-action@v3

--- a/.github/workflows/build-and-push-docker-image.yml
+++ b/.github/workflows/build-and-push-docker-image.yml
@@ -27,6 +27,10 @@ on:
         type: string
         default: ghcr.io
         description: "The registry to push the image to (Default: ghcr.io)"
+      network:
+        type: string
+        default: default
+        description: "Networking mode for the RUN instructions during build (Default: default)"
       
     secrets:
       registry-user:
@@ -78,4 +82,5 @@ jobs:
           tags: ${{ steps.meta.outputs.tags }}
           labels: ${{ steps.meta.outputs.labels }}
           build-args: ${{ inputs.build-args }}
+          network: ${{ inputs.network }}
           push: true


### PR DESCRIPTION
Siehe LS1ADMIN-38225; es gibt Probleme mit DNS in Docker-Containers. Obwohl ich annehme dass ich das morgen lösen werde wäre dieser Workaround mMn keine schlechte Idee