### PR TITLE
Fix image tag exist check

### DIFF
--- a/.github/workflows/deploy-docker-compose.yml
+++ b/.github/workflows/deploy-docker-compose.yml
@@ -84,9 +84,11 @@ jobs:
           IMAGE_TAG="${{ steps.retrieve-image-tag.outputs.image-tag-to-deploy }}"
 
           ENCODED_TOKEN=$(echo -n "${{ secrets.GITHUB_TOKEN }}" | base64)
-          TAG_EXISTS=$(curl -s -H "Authorization: Bearer ${ENCODED_TOKEN}" \
-            https://ghcr.io/v2/${IMAGE_NAME}/tags/list \
-            | jq -r --arg TAG "${IMAGE_TAG}" '.tags[] | select(. == $TAG)')
+          RESPONSE=$(curl -s -H "Authorization: Bearer ${ENCODED_TOKEN}" "https://ghcr.io/v2/${IMAGE_NAME}/tags/list")
+          echo "Response: $RESPONSE"
+
+          TAG_EXISTS=$(echo "$RESPONSE" | jq -r --arg TAG "${IMAGE_TAG}" '.tags[] | select(. == $TAG)')
+          echo "Tag exists: ${TAG_EXISTS}"
           
           if [ -z "$TAG_EXISTS" ]; then
             echo "Image ${IMAGE_NAME}:${IMAGE_TAG} does not exist."

--- a/.github/workflows/deploy-docker-compose.yml
+++ b/.github/workflows/deploy-docker-compose.yml
@@ -87,7 +87,7 @@ jobs:
 
           ENCODED_TOKEN=$(echo -n "${{ secrets.GITHUB_TOKEN }}" | base64)
           STATUS=$(curl -s -o /dev/null -w "%{http_code}" \
-            -H "Accept: application/vnd.docker.distribution.manifest.v2+json, application/vnd.docker.distribution.manifest.list.v2+json" \
+            -H "Accept: application/vnd.docker.distribution.manifest.v2+json,application/vnd.docker.distribution.manifest.list.v2+json,application/vnd.oci.image.manifest.v1+json,application/vnd.oci.image.index.v1+json" \
             -H "Authorization: Bearer ${ENCODED_TOKEN}" \
             "https://ghcr.io/v2/${IMAGE_NAME}/manifests/${IMAGE_TAG}")
           

--- a/.github/workflows/deploy-docker-compose.yml
+++ b/.github/workflows/deploy-docker-compose.yml
@@ -84,17 +84,18 @@ jobs:
           IMAGE_TAG="${{ steps.retrieve-image-tag.outputs.image-tag-to-deploy }}"
 
           ENCODED_TOKEN=$(echo -n "${{ secrets.GITHUB_TOKEN }}" | base64)
-          RESPONSE=$(curl -s -H "Authorization: Bearer ${ENCODED_TOKEN}" "https://ghcr.io/v2/${IMAGE_NAME}/tags/list")
-          echo "Response: $RESPONSE"
-
-          TAG_EXISTS=$(echo "$RESPONSE" | jq -r --arg TAG "${IMAGE_TAG}" '.tags[] | select(. == $TAG)')
-          echo "Tag exists: ${TAG_EXISTS}"
+          STATUS=$(curl -s -o /dev/null -w "%{http_code}" \
+            -H "Accept: application/vnd.docker.distribution.manifest.v2+json" \
+            -H "Authorization: Bearer ${ENCODED_TOKEN}" \
+            "https://ghcr.io/v2/${IMAGE_NAME}/manifests/${IMAGE_TAG}")
           
-          if [ -z "$TAG_EXISTS" ]; then
+          echo "HTTP status: $STATUS"
+          
+          if [ "$STATUS" -eq "200" ]; then
+            echo "Image ${IMAGE_NAME}:${IMAGE_TAG} exists."
+          else
             echo "Image ${IMAGE_NAME}:${IMAGE_TAG} does not exist."
             exit 1
-          else
-            echo "Image ${IMAGE_NAME}:${IMAGE_TAG} exists."
           fi
 
   deploy:

--- a/.github/workflows/deploy-docker-compose.yml
+++ b/.github/workflows/deploy-docker-compose.yml
@@ -83,9 +83,11 @@ jobs:
           IMAGE_NAME="${{ inputs.main-image-name }}"
           IMAGE_TAG="${{ steps.retrieve-image-tag.outputs.image-tag-to-deploy }}"
 
+          echo "Checking for image ${IMAGE_NAME}:${IMAGE_TAG}"
+
           ENCODED_TOKEN=$(echo -n "${{ secrets.GITHUB_TOKEN }}" | base64)
           STATUS=$(curl -s -o /dev/null -w "%{http_code}" \
-            -H "Accept: application/vnd.docker.distribution.manifest.v2+json" \
+            -H "Accept: application/vnd.docker.distribution.manifest.v2+json, application/vnd.docker.distribution.manifest.list.v2+json" \
             -H "Authorization: Bearer ${ENCODED_TOKEN}" \
             "https://ghcr.io/v2/${IMAGE_NAME}/manifests/${IMAGE_TAG}")
           


### PR DESCRIPTION
### Motivation

Image tag check was not working properly for specific tags.

### Description

Improvements to Docker image existence check:

* [`.github/workflows/deploy-docker-compose.yml`](diffhunk://#diff-16eb9aedfbe7a46d8795104973919a7d71049eb60fb98e55c0bdafb7f017c726R86-L95): Replaced the method of checking for an image tag's existence by querying the Docker registry's manifest endpoint and checking the HTTP status code. This change includes adding a new echo statement to log the HTTP status code for better debugging.


**Worked as seen here:**

https://github.com/ls1intum/Hephaestus/actions/runs/13636012537/job/38114871351

![image](https://github.com/user-attachments/assets/37251263-2435-4536-9870-9b4b93cf6665)
