### PR TITLE
feat: add multi-tag support

### DIFF
--- a/.github/workflows/build-and-push-docker-image.yml
+++ b/.github/workflows/build-and-push-docker-image.yml
@@ -176,6 +176,7 @@ jobs:
           echo "TAGS_CONFIG<<EOF" >> $GITHUB_ENV
           
           # Default tagging configuration
+          echo "type=raw,value=latest,enable={{is_default_branch}}" >> $GITHUB_ENV
           echo "type=ref,event=branch" >> $GITHUB_ENV
           echo "type=ref,event=pr" >> $GITHUB_ENV
           

--- a/.github/workflows/build-and-push-docker-image.yml
+++ b/.github/workflows/build-and-push-docker-image.yml
@@ -30,7 +30,11 @@ on:
         required: false
       tags:
         type: string
-        description: "Tags that should be appended to the image"
+        description: |
+          Tags for the image. Supports flexible formats:
+          - Comma-separated simple tags (e.g., "v1.0,latest,stable")
+          - Full docker/metadata-action tag configuration (e.g., "type=semver,pattern={{version}}")
+          - Mixed format with multiple lines (e.g., "v1.0,stable" on one line and "type=semver,pattern={{version}}" on another)
         required: false
       registry:
         type: string
@@ -164,15 +168,53 @@ jobs:
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v3
 
+      # Process tags input to support both simple tags and advanced configuration
+      - name: Prepare tag configuration
+        id: tag_config
+        run: |
+          # Use TAGS_CONFIG environment variable to store tags configuration
+          echo "TAGS_CONFIG<<EOF" >> $GITHUB_ENV
+          
+          # Default tagging configuration
+          echo "type=ref,event=branch" >> $GITHUB_ENV
+          echo "type=ref,event=pr" >> $GITHUB_ENV
+          
+          # Check if tags input is provided
+          if [ -n "${{ inputs.tags }}" ]; then
+            # Process input line by line
+            echo "${{ inputs.tags }}" | while IFS= read -r line || [[ -n "$line" ]]; do
+              # Trim whitespace
+              line=$(echo "$line" | xargs)
+          
+              if [ -n "$line" ]; then
+                if [[ "$line" == *"type="* ]]; then
+                  # Line contains configuration, add it directly
+                  echo "$line" >> $GITHUB_ENV
+                else
+                  # Line contains simple tags, process as comma-separated list
+                  IFS=',' read -ra TAG_ARRAY <<< "$line"
+                  for tag in "${TAG_ARRAY[@]}"; do
+                    # Trim whitespace from each tag
+                    tag=$(echo "$tag" | xargs)
+                    if [ -n "$tag" ]; then
+                      echo "type=raw,value=${tag}" >> $GITHUB_ENV
+                    fi
+                  done
+                fi
+              fi
+            done
+          fi
+          
+          echo "EOF" >> $GITHUB_ENV
+
+
       - name: Extract metadata (tags, labels) for Docker
         id: meta
         uses: docker/metadata-action@v5
         with:
           images: ${{ inputs.registry }}/${{ inputs.image-name }}
           tags: |
-            type=raw,value=${{ inputs.tags }}
-            type=ref,event=branch
-            type=ref,event=pr
+            ${{ env.TAGS_CONFIG }}
           labels: |
             ${{ inputs.labels }}        
 

--- a/.github/workflows/build-and-push-docker-image.yml
+++ b/.github/workflows/build-and-push-docker-image.yml
@@ -170,7 +170,6 @@ jobs:
         with:
           images: ${{ inputs.registry }}/${{ inputs.image-name }}
           tags: |
-            type=raw,value=latest,enable={{is_default_branch}}
             type=raw,value=${{ inputs.tags }}
             type=ref,event=branch
             type=ref,event=pr


### PR DESCRIPTION
This PR enhances our Docker tagging logic by adding support for multiple tags and advanced metadata rules. It allows passing either comma-separated raw tags or fully defined docker/metadata-action parameters, ensuring more flexible and comprehensive Docker image tagging while preserving the existing branch/PR-based tags.

## What's Changed

- Multi-tag + Advanced Docker Metadata support
  - Pass comma-separated tags or full [docker/metadata-action](https://github.com/docker/metadata-action) rules. 
  - Each line is parsed into metadata-action rules. If a line already contains `type=`, it’s treated as a complete rule (like `type=sha,prefix=,format=long`). Otherwise, it’s assumed to be comma-separated raw tags.
  - **Note on raw tags:** The  [docker/metadata-action](https://github.com/docker/metadata-action) action only accepts one value per raw rule (e.g., `type=raw,value=XYZ`). If you need multiple raw tags, you must emit one line per tag. [This GitHub issue](https://github.com/docker/metadata-action/issues/298) confirms there’s no built-in multi-value raw feature, so a custom logic is required (as implemented in this PR).

**Example:**
```yaml
with:
  tags: |
    latest
    type=sha,prefix=,format=long
```
This translates to:
- `type=raw,value=latest`
- `type=sha,prefix=,format=long`

## Unchanged
- Ref-based Tags & tagging `latest` on default branch Remain
  - The workflow still generates `branch`/`PR` tags with `type=ref,event=branch` and `type=ref,event=pr`.
  - Also the latest tag on default branch with `type=raw,value=latest,enable={{is_default_branch}}` remains unchanged.


## Previously
- When calling the reusable workflow during a pull request (event = pull_request), the tag generation followed these rules:
```yaml
type=raw,value=latest,enable={{is_default_branch}} # Skipped, because not the default branch
type=ref,event=branch # Skipped, because event is not branch push
type=ref,event=pr # Evaluates to "pr-10451"
type=raw,value=pr-10451 # Comes from the tags input
```
- Because `type=raw,value=latest` was disabled (not the default branch) and `type=ref,event=branch` was ignored (not a branch push), only `pr-10451` remained. The workflow ended up pushing a single Docker image tag:
![image](https://github.com/user-attachments/assets/3b3f92e0-d574-40cf-b95f-50a36448de31)

- [Workflowrun link](https://github.com/ls1intum/Artemis/actions/runs/13775919540/job/38525526244?pr=10451)

## After changes
- Now, the reusable workflow supports multiple tags (both `raw` tags and advanced docker/metadata-action rules). For the same pull request scenario, the caller workflow provides:
```yaml
    with:
      tags: |
        chore-refactor-workflows-test-multi-tag-step
        ${{ inputs.docker_build_tag }} # which is pr-10451
```
- So the new workflow generated tags like below
```yaml
type=raw,value=latest,enable={{is_default_branch}} # Skipped, because not the default branch
type=ref,event=branch   # still skipped for pull_request events
type=ref,event=pr       # resolves to pr-10451
type=raw,value=chore-refactor-workflows-test-multi-tag-step
type=raw,value=pr-10451
```
- So the generated image has two tags (`pr-10451` and `chore-refactor-workflows-test-multi-tag-step`)
![image](https://github.com/user-attachments/assets/e8c244d3-bd84-4a8b-bb1f-512d6309abd9)
![image](https://github.com/user-attachments/assets/da9c211e-7ad4-4da2-982b-3d19cd228fa9)

- [Workflowrun link](https://github.com/ls1intum/Artemis/actions/runs/13776868406/job/38528147651?pr=10451)





