### PR TITLE
docs: add instructions to fix “Permission denied” when switching to `github_deployment`

### DIFF
--- a/README.md
+++ b/README.md
@@ -111,6 +111,9 @@ jobs:
 > pam_access(su:session): access denied for user `github_deployment' from `pts/…'
 > ```
 > then PAM is blocking `github_deployment` because of an `/etc/security/access.conf` rule. Some VMs ship with this file empty (no restrictions), while others have existing allow/deny rules—either way, you need to ensure there is a `+` line permitting our deployment user before any `deny all`.
+> 
+> > ⚠️ **Warning:** Following the steps below introduces security risks, since it grants the deployment user broad access to the system. You should carefully consider the implications and, if possible, restrict `github_deployment` to only the specific commands or directories it truly needs.
+> 
 > - Open `/etc/security/access.conf` (as root):
 > ```bash
 > sudo vi /etc/security/access.conf

--- a/README.md
+++ b/README.md
@@ -98,6 +98,49 @@ jobs:
 4. Add `github_deployment` to the docker group: `sudo usermod -aG docker github_deployment`
 5. Create the deployment directory `/opt/github` and give `github_deployment` access: `sudo mkdir /opt/github && sudo chown github_deployment:github_deployment /opt/github`
 6. Switch to `github_deployment` user: `sudo su github_deployment`
+> <details>
+> <summary>Note on fixing “access denied” when switching to deployment user</summary>
+>
+> If, when you run:
+> ```bash
+> sudo su github_deployment
+> ```
+> you see an error like:
+> ```bash
+> su: cannot open session: Permission denied
+> pam_access(su:session): access denied for user `github_deployment' from `pts/…'
+> ```
+> then PAM is blocking `github_deployment` because of an `/etc/security/access.conf` rule. Some VMs ship with this file empty (no restrictions), while others have existing allow/deny rules—either way, you need to ensure there is a `+` line permitting our deployment user before any `deny all`.
+> - Open `/etc/security/access.conf` (as root):
+> ```bash
+> sudo vi /etc/security/access.conf
+> ```
+> - Add the following line:
+> ```bash
+> # Allow github_deployment user to access the system
+> +:github_deployment : ALL
+> ```
+> - The file should look like this:
+> ```bash
+> # login restriction for pam_access
+> # ldap admin/user group login
+> +:(asevm90-admin) (asevm90-user):ALL
+> # allow local root user and root/login group logins
+> +:root (login) (root):ALL
+> # Allow github_deployment user to login
+> +:github_deployment : ALL
+> # deny rest
+> -:ALL:ALL
+> ```
+> - Save and exit.
+> - Retry
+> ```bash
+> sudo su github_deployment
+> ```
+>   
+>
+> </details>
+
 7. Generate a new SSH key on VM: `ssh-keygen -t ed25519 -C "github_deployment@<VMHost>"`, leave passphrase empty
 8. Copy the public key to the authorized keys: `cat /home/github_deployment/.ssh/id_ed25519.pub > /home/github_deployment/.ssh/authorized_keys`
 9. Copy the private key to your clipboard: `cat /home/github_deployment/.ssh/id_ed25519`


### PR DESCRIPTION
## Description

While following the `README`, I ran into a “Permission denied” error on one of our VMs when switching to `github_deployment`. It turned out that some VMs ship with a pre-populated `/etc/security/access.conf`, while others do not. To prevent others from hitting this, I have added a brief note on:
- Updating `/etc/security/access.conf` to allow the `github_deployment`

## Screenshots
![image](https://github.com/user-attachments/assets/7e4b7cd2-e0df-498e-ba4d-6f61991e7f76)
### Expanded
![image](https://github.com/user-attachments/assets/9ac673c3-3a16-4785-9fe5-0ef3ade0ec21)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Documentation**
  - Added a detailed collapsible note to the README with troubleshooting steps for resolving "access denied" errors when switching to the `github_deployment` user, including instructions for editing access control settings.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->