### PR TITLE
feat: include matrix.platform in build job name

### DIFF
--- a/.github/workflows/build-and-push-docker-image.yml
+++ b/.github/workflows/build-and-push-docker-image.yml
@@ -57,7 +57,7 @@ on:
 
 jobs:
   build:
-    name: Build Docker Image for ${{ inputs.image-name }}
+    name: Build ${{ matrix.platform }} Docker Image for ${{ inputs.image-name }}
     strategy:
       fail-fast: false
       matrix:


### PR DESCRIPTION
## Description

This change updates the reusable workflow’s build job name to include `${{ matrix.platform }}`, so that `ARM` and `AMD` build jobs are clearly distinguished. @krusche pointed out the same naming confusion during our Helios meeting.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Chores**
  - Updated workflow job names to display the platform being used when building Docker images, improving clarity in multi-platform build processes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->