### PR TITLE
fix(deploy): minimize downtime by pre-pulling images

### DIFF
--- a/.github/workflows/deploy-docker-compose.yml
+++ b/.github/workflows/deploy-docker-compose.yml
@@ -251,4 +251,4 @@ jobs:
           proxy_key: ${{ secrets.DEPLOYMENT_GATEWAY_SSH_KEY }}
           proxy_port: ${{ vars.DEPLOYMENT_GATEWAY_PORT }}
           script: |
-            docker image prune -f
+            docker image prune -af

--- a/.github/workflows/deploy-docker-compose.yml
+++ b/.github/workflows/deploy-docker-compose.yml
@@ -119,7 +119,8 @@ jobs:
           cp "${{ inputs.docker-compose-file }}" "$BASENAME"
         shell: bash
 
-      - name: SSH to VM and execute docker compose down (if exists)
+      - name: SSH to VM and execute docker compose down (only if removing volumes)
+        if: ${{ inputs.remove-volumes }}
         uses: appleboy/ssh-action@v1.2.5
         with:
           host: ${{ vars.VM_HOST }}
@@ -131,20 +132,17 @@ jobs:
           proxy_port: ${{ vars.DEPLOYMENT_GATEWAY_PORT }}
           script: |
             #!/bin/bash
-            set -e  # Exit immediately if a command exits with a non-zero status
+            set -e
 
             BASE_PATH="${{ inputs.deployment-base-path }}"
             COMPOSE_FILE="$BASE_PATH/${{ steps.extract-basename.outputs.basename }}"
 
-            # Check if docker-compose file exists
             if [ -f "$COMPOSE_FILE" ]; then
-              echo "$COMPOSE_FILE found."
-          
-              # Check if .env with env-file-name exists
+              echo "$COMPOSE_FILE found. Removing volumes as requested."
               if [ -f "$BASE_PATH/${{ inputs.env-file-name }}" ]; then
-                docker compose -f "$COMPOSE_FILE" --env-file="$BASE_PATH/${{ inputs.env-file-name }}" down --remove-orphans --rmi all ${{ inputs.remove_volumes && '--volumes' || '' }}
+                docker compose -f "$COMPOSE_FILE" --env-file="$BASE_PATH/${{ inputs.env-file-name }}" down --remove-orphans --volumes
               else
-                docker compose -f "$COMPOSE_FILE" down --remove-orphans --rmi all
+                docker compose -f "$COMPOSE_FILE" down --remove-orphans --volumes
               fi
             else
               echo "$COMPOSE_FILE does not exist. Skipping docker compose down."
@@ -213,6 +211,20 @@ jobs:
           source: ${{ inputs.env-file-name }}
           target: ${{ inputs.deployment-base-path }}
 
+      - name: SSH to VM and pull new images
+        uses: appleboy/ssh-action@v1.2.5
+        with:
+          host: ${{ vars.VM_HOST }}
+          username: ${{ vars.VM_USERNAME }}
+          key: ${{ secrets.VM_SSH_PRIVATE_KEY }}
+          proxy_host: ${{ vars.DEPLOYMENT_GATEWAY_HOST }}
+          proxy_username: ${{ vars.DEPLOYMENT_GATEWAY_USER }}
+          proxy_key: ${{ secrets.DEPLOYMENT_GATEWAY_SSH_KEY }}
+          proxy_port: ${{ vars.DEPLOYMENT_GATEWAY_PORT }}
+          script: |
+            BASE_PATH="${{ inputs.deployment-base-path }}"
+            docker compose -f "$BASE_PATH/${{ steps.extract-basename.outputs.basename }}" --env-file="$BASE_PATH/${{ inputs.env-file-name }}" pull
+
       - name: SSH to VM and execute docker compose up
         uses: appleboy/ssh-action@v1.2.5
         with:
@@ -225,4 +237,17 @@ jobs:
           proxy_port: ${{ vars.DEPLOYMENT_GATEWAY_PORT }}
           script: |
             BASE_PATH="${{ inputs.deployment-base-path }}"
-            docker compose -f "$BASE_PATH/${{ steps.extract-basename.outputs.basename }}" --env-file="$BASE_PATH/${{ inputs.env-file-name }}" up --pull=always -d
+            docker compose -f "$BASE_PATH/${{ steps.extract-basename.outputs.basename }}" --env-file="$BASE_PATH/${{ inputs.env-file-name }}" up -d --remove-orphans
+
+      - name: SSH to VM and clean up old images
+        uses: appleboy/ssh-action@v1.2.5
+        with:
+          host: ${{ vars.VM_HOST }}
+          username: ${{ vars.VM_USERNAME }}
+          key: ${{ secrets.VM_SSH_PRIVATE_KEY }}
+          proxy_host: ${{ vars.DEPLOYMENT_GATEWAY_HOST }}
+          proxy_username: ${{ vars.DEPLOYMENT_GATEWAY_USER }}
+          proxy_key: ${{ secrets.DEPLOYMENT_GATEWAY_SSH_KEY }}
+          proxy_port: ${{ vars.DEPLOYMENT_GATEWAY_PORT }}
+          script: |
+            docker image prune -f

--- a/.github/workflows/deploy-docker-compose.yml
+++ b/.github/workflows/deploy-docker-compose.yml
@@ -221,6 +221,7 @@ jobs:
           proxy_username: ${{ vars.DEPLOYMENT_GATEWAY_USER }}
           proxy_key: ${{ secrets.DEPLOYMENT_GATEWAY_SSH_KEY }}
           proxy_port: ${{ vars.DEPLOYMENT_GATEWAY_PORT }}
+          command_timeout: 30m
           script: |
             BASE_PATH="${{ inputs.deployment-base-path }}"
             docker compose -f "$BASE_PATH/${{ steps.extract-basename.outputs.basename }}" --env-file="$BASE_PATH/${{ inputs.env-file-name }}" pull
@@ -235,7 +236,6 @@ jobs:
           proxy_username: ${{ vars.DEPLOYMENT_GATEWAY_USER }}
           proxy_key: ${{ secrets.DEPLOYMENT_GATEWAY_SSH_KEY }}
           proxy_port: ${{ vars.DEPLOYMENT_GATEWAY_PORT }}
-          command_timeout: 30m
           script: |
             BASE_PATH="${{ inputs.deployment-base-path }}"
             docker compose -f "$BASE_PATH/${{ steps.extract-basename.outputs.basename }}" --env-file="$BASE_PATH/${{ inputs.env-file-name }}" up -d --remove-orphans


### PR DESCRIPTION
## Summary
- **Remove unconditional `docker compose down --rmi all`** — previously this stopped all containers and deleted all images on every deployment, even when not needed. Now `down` only runs when `remove-volumes: true`.
- **Add `docker compose pull` step** before `up` — pre-pulls new images while old containers still serve traffic (zero downtime during the slow registry pull).
- **Change `up --pull=always` to `up -d --remove-orphans`** — since images are already pulled, this only recreates containers whose image/config changed (seconds vs minutes).
- **Add `docker image prune -f` cleanup step** — removes dangling old image layers after deployment.

### Downtime comparison
| Phase | Before | After |
|-------|--------|-------|
| Image pull | Services **DOWN** (minutes if registry is slow) | Old containers **still serving traffic** |
| Container recreation | Services **DOWN** | ~2-10s per changed service |
| **Total downtime** | **2-10+ minutes** | **~2-10 seconds** |

### How it works
`docker compose up -d --remove-orphans` compares running state vs desired state:
- **Changed image/config** → stops old container, starts new one from already-pulled image (seconds)
- **Same image** → container stays running untouched (e.g., postgres)
- **Removed services** → cleaned up by `--remove-orphans`
- **New services** → started automatically

### Motivation
Production deployment of [Hephaestus](https://github.com/ls1intum/Hephaestus) experienced extended downtime due to slow ghcr.io image pulls: https://github.com/ls1intum/Hephaestus/actions/runs/22673990625/job/65725409644

## Test plan
- [ ] Deploy to a staging environment and verify old containers serve traffic during image pull
- [ ] Verify `docker compose up -d --remove-orphans` only recreates changed services
- [ ] Test `remove-volumes: true` still runs `docker compose down -v` correctly
- [ ] Verify `docker image prune -f` cleans up old images after deployment

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Improved deployment workflow for better Docker image management
  * Pull latest images before starting services (separate pull step)
  * Start services while removing orphaned containers
  * Prune unused images after deployment
  * Make volume removal during teardown optional and clarify messaging
<!-- end of auto-generated comment: release notes by coderabbit.ai -->