### PR TITLE
fix: prevent artifact name prefix collision in multi-arch merge step

### DIFF
--- a/.github/workflows/build-and-push-docker-image.yml
+++ b/.github/workflows/build-and-push-docker-image.yml
@@ -134,7 +134,7 @@ jobs:
       - name: Upload digest
         uses: actions/upload-artifact@v6
         with:
-          name: digests-${{ env.IMAGE_NAME }}-${{ env.PLATFORM_PAIR }}
+          name: digests-${{ github.run_id }}-${{ env.IMAGE_NAME }}-${{ env.PLATFORM_PAIR }}
           path: ${{ runner.temp }}/digests/*
           if-no-files-found: error
           retention-days: 1
@@ -155,7 +155,7 @@ jobs:
         uses: actions/download-artifact@v7
         with:
           path: ${{ runner.temp }}/digests
-          pattern: digests-${{ env.IMAGE_NAME }}-*
+          pattern: digests-${{ github.run_id }}-${{ env.IMAGE_NAME }}-linux-*
           merge-multiple: true
 
       - name: Login to GHCR


### PR DESCRIPTION
## Problem

The `merge` job in `build-and-push-docker-image.yml` uses a glob pattern to download platform-specific digests:

```
pattern: digests-{IMAGE_NAME}-*
```

This causes a prefix collision when multiple images share a common name prefix. For example:
- `eduide/eduide/rust` → artifact name: `digests-eduide-eduide-rust-linux-amd64`
- `eduide/eduide/rust-no-ls` → artifact name: `digests-eduide-eduide-rust-no-ls-linux-amd64`

The pattern `digests-eduide-eduide-rust-*` matches **both** artifacts. When `rust-no-ls` artifacts are uploaded before the `rust` merge job runs, the merge step downloads wrong digests and fails with:

```
ERROR: ghcr.io/eduide/eduide/rust@sha256:...: not found
```

This is **flaky** because it only fails when the sibling image's artifacts happen to be uploaded before the merge step starts.

The same issue affects `java-17` vs `java-17-no-ls`.

## Fix

Two changes:
1. Add `${{ github.run_id }}` to artifact names — scopes artifacts to the current run, preventing cross-run interference
2. Change the download pattern to use `-linux-*` suffix — `rust-linux-*` no longer matches `rust-no-ls-linux-*`

## Testing

This fix mirrors the approach already used in the `feature/arc-runner-support` branch (see `arc-digests-${{ github.run_id }}-...` naming there).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated GitHub Actions workflow for Docker image building to refine artifact identification and selection logic in the build and merge stages.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->