### PR TITLE
Split build-and-push workflow into router + mode-specific reusable workflows

### DIFF
--- a/.github/workflows/build-and-push-docker-image-github-runners.yml
+++ b/.github/workflows/build-and-push-docker-image-github-runners.yml
@@ -1,0 +1,477 @@
+name: Build and Push Docker Image (GitHub Runners)
+
+on:
+  workflow_call:
+    inputs:
+      ref:
+        description: "The branch name, tag, or commit SHA to use for the build job."
+        required: false
+        default: ''
+        type: string
+      image-name:
+        type: string
+        default: ${{ github.repository }}
+        description: "The name for the docker image (Default: Repository name)"
+      docker-file:
+        type: string
+        default: Dockerfile
+        description: "The path to the Dockerfile (Default: ./Dockerfile)"
+      docker-context:
+        type: string
+        default: .
+        description: "The context for the Docker build (Default: .)"
+      build-args:
+        type: string
+        description: "List of additional build contexts (e.g., name=path)"
+        required: false
+      labels:
+        type: string
+        description: "Label that should be appended to the image"
+        required: false
+      tags:
+        type: string
+        description: |
+          Tags for the image. Supports flexible formats:
+          - Comma-separated simple tags (e.g., "v1.0,latest,stable")
+          - Full docker/metadata-action tag configuration (e.g., "type=semver,pattern={{version}}")
+          - Mixed format with multiple lines (e.g., "v1.0,stable" on one line and "type=semver,pattern={{version}}" on another)
+        required: false
+      image-tag:
+        type: string
+        default: ''
+        description: "Optional base image tag override (e.g. my-test-tag)"
+      registry:
+        type: string
+        default: ghcr.io
+        description: "The registry to push the image to (Default: ghcr.io)"
+      network:
+        type: string
+        default: default
+        description: "Networking mode for the RUN instructions during build (Default: default)"
+      no-cache:
+        type: boolean
+        default: false
+        description: "Disable Docker layer cache (--no-cache). BuildKit mount caches remain available."
+      cache-from:
+        type: string
+        default: ''
+        description: "Optional buildx cache-from configuration for github-runners mode"
+      cache-to:
+        type: string
+        default: ''
+        description: "Optional buildx cache-to configuration for github-runners mode"
+      registry-mirror:
+        type: string
+        default: ''
+        description: "Optional mirror endpoint (host:port or URL). If cache refs are not set, github-runners derive cache refs from this mirror."
+      runner-amd64:
+        type: string
+        default: ubuntu-24.04
+        description: "Runner to use for linux/amd64 builds"
+      runner-arm64:
+        type: string
+        default: ubuntu-24.04-arm
+        description: "Runner to use for linux/arm64 builds"
+      runner-merge:
+        type: string
+        default: ubuntu-latest
+        description: "Runner to use for the merge job (default: ubuntu-latest)"
+      build-amd64:
+        type: boolean
+        default: true
+        description: "Enable AMD64 build (default: true)"
+      build-arm64:
+        type: boolean
+        default: true
+        description: "Enable ARM64 build (default: true)"
+    outputs:
+      image_tag:
+        description: "The tag of the image that was built"
+        value: ${{ jobs.merge.outputs.image_tag || jobs.build.outputs.image_tag }}
+      base_tag:
+        description: "Derived base Docker tag"
+        value: ${{ jobs.setup-matrix.outputs.base_tag }}
+      sha_tag:
+        description: "Derived immutable Docker tag with short SHA suffix"
+        value: ${{ jobs.setup-matrix.outputs.sha_tag }}
+      cache_tag:
+        description: "Derived cache tag namespace"
+        value: ${{ jobs.setup-matrix.outputs.cache_tag }}
+      image_repo:
+        description: "Lower-cased owner/repository name"
+        value: ${{ jobs.setup-matrix.outputs.image_repo }}
+
+    secrets:
+      registry-user:
+        required: false
+      registry-password:
+        required: false
+      docker-secrets:
+        required: false
+        description: "Secrets to pass to Docker build (e.g., 'SECRET_NAME=secret_value')"
+
+jobs:
+  setup-matrix:
+    runs-on: ${{ inputs.runner-merge || 'ubuntu-latest' }}
+    outputs:
+      matrix: ${{ steps.setup.outputs.matrix }}
+      needs_merge: ${{ steps.setup.outputs.needs_merge }}
+      base_tag: ${{ steps.setup.outputs.base_tag }}
+      sha_tag: ${{ steps.setup.outputs.sha_tag }}
+      cache_tag: ${{ steps.setup.outputs.cache_tag }}
+      image_repo: ${{ steps.setup.outputs.image_repo }}
+    steps:
+      - id: setup
+        shell: bash
+        run: |
+          set -euo pipefail
+
+          SHORT_SHA="${GITHUB_SHA::7}"
+          REF_NAME="${GITHUB_REF_NAME}"
+          SAFE_REF_NAME=$(echo "${REF_NAME}" | tr '[:upper:]' '[:lower:]' | tr -c 'a-z0-9_.-' '-')
+          IMAGE_REPO=$(echo "${GITHUB_REPOSITORY}" | tr '[:upper:]' '[:lower:]')
+
+          OVERRIDE="${{ inputs.image-tag }}"
+          PR_NUMBER="${{ github.event.pull_request.number || '' }}"
+          RELEASE_TAG="${{ github.event.release.tag_name || '' }}"
+          if [[ -n "${OVERRIDE}" ]]; then
+            BASE_TAG="${OVERRIDE}"
+          elif [[ "${GITHUB_EVENT_NAME}" == "pull_request" ]]; then
+            if [[ -z "${PR_NUMBER}" ]]; then
+              echo "::error::pull_request event detected but PR number is missing"
+              exit 1
+            fi
+            BASE_TAG="pr-${PR_NUMBER}"
+          elif [[ "${GITHUB_EVENT_NAME}" == "release" ]]; then
+            if [[ -n "${RELEASE_TAG}" ]]; then
+              BASE_TAG=$(echo "${RELEASE_TAG}" | tr '[:upper:]' '[:lower:]' | tr -c 'a-z0-9_.-' '-')
+            else
+              BASE_TAG="${SAFE_REF_NAME}"
+            fi
+          elif [[ "${GITHUB_REF}" == "refs/heads/main" || "${GITHUB_REF}" == "refs/heads/master" ]]; then
+            BASE_TAG="latest"
+          else
+            BASE_TAG="${SAFE_REF_NAME}"
+          fi
+
+          if [[ "${GITHUB_EVENT_NAME}" == "pull_request" ]]; then
+            CACHE_TAG="build-cache-pr-${PR_NUMBER}"
+          elif [[ "${BASE_TAG}" == "latest" ]]; then
+            CACHE_TAG="build-cache"
+          else
+            CACHE_TAG="build-cache-${BASE_TAG}"
+          fi
+
+          MATRIX='{"include":['
+          PLATFORMS=()
+
+          if [[ "${{ inputs.build-amd64 }}" == "true" ]]; then
+            PLATFORMS+=('{"platform":"linux/amd64","runner":"${{ inputs.runner-amd64 }}"}')
+          fi
+
+          if [[ "${{ inputs.build-arm64 }}" == "true" ]]; then
+            PLATFORMS+=('{"platform":"linux/arm64","runner":"${{ inputs.runner-arm64 }}"}')
+          fi
+
+          JOINED=$(IFS=,; echo "${PLATFORMS[*]}")
+          MATRIX="${MATRIX}${JOINED}]}"
+
+          if [[ ${#PLATFORMS[@]} -gt 1 ]]; then
+            NEEDS_MERGE="true"
+          else
+            NEEDS_MERGE="false"
+          fi
+
+          echo "base_tag=${BASE_TAG}" >> "$GITHUB_OUTPUT"
+          echo "sha_tag=${BASE_TAG}-${SHORT_SHA}" >> "$GITHUB_OUTPUT"
+          echo "cache_tag=${CACHE_TAG}" >> "$GITHUB_OUTPUT"
+          echo "image_repo=${IMAGE_REPO}" >> "$GITHUB_OUTPUT"
+          echo "matrix=${MATRIX}" >> "$GITHUB_OUTPUT"
+          echo "needs_merge=${NEEDS_MERGE}" >> "$GITHUB_OUTPUT"
+
+  build:
+    name: Build ${{ matrix.platform }} Docker Image for ${{ inputs.image-name }}
+    needs: setup-matrix
+    if: needs.setup-matrix.outputs.matrix != '{"include":[]}'
+    strategy:
+      fail-fast: true
+      matrix: ${{ fromJSON(needs.setup-matrix.outputs.matrix) }}
+    runs-on: ${{ matrix.runner || 'ubuntu-latest' }}
+    outputs:
+      image_tag: ${{ steps.output-image-tag.outputs.image_tag }}
+    steps:
+      - name: Git Checkout (specific ref)
+        uses: actions/checkout@v6
+        if: ${{ inputs.ref != '' }}
+        with:
+          ref: ${{ inputs.ref }}
+      - name: Git Checkout (default)
+        uses: actions/checkout@v6
+        if: ${{ inputs.ref == '' }}
+        with:
+          fetch-depth: 1
+
+      - name: Install Docker Buildx
+        id: setup-buildx
+        uses: docker/setup-buildx-action@v4
+
+      - name: Prepare build args
+        id: build-args
+        run: |
+          BUILD_ARGS="${{ inputs.build-args }}"
+
+          echo "build-args<<EOF" >> $GITHUB_OUTPUT
+          echo "$BUILD_ARGS" >> $GITHUB_OUTPUT
+          echo "EOF" >> $GITHUB_OUTPUT
+
+      - name: Log in to the Container registry
+        uses: docker/login-action@v4
+        with:
+          registry: ${{ inputs.registry }}
+          username: ${{ secrets.registry-user || github.actor }}
+          password: ${{ secrets.registry-password || secrets.GITHUB_TOKEN }}
+
+      - name: Prepare tag configuration
+        id: tag_config
+        run: |
+          echo "TAGS_CONFIG<<EOF" >> $GITHUB_ENV
+
+          echo "type=raw,value=${{ needs.setup-matrix.outputs.base_tag }}" >> $GITHUB_ENV
+          echo "type=raw,value=${{ needs.setup-matrix.outputs.sha_tag }}" >> $GITHUB_ENV
+
+          if [ -n "${{ inputs.tags }}" ]; then
+            echo "${{ inputs.tags }}" | while IFS= read -r line || [[ -n "$line" ]]; do
+              line=$(echo "$line" | xargs)
+
+              if [ -n "$line" ]; then
+                if [[ "$line" == *"type="* ]]; then
+                  echo "$line" >> $GITHUB_ENV
+                else
+                  IFS=',' read -ra TAG_ARRAY <<< "$line"
+                  for tag in "${TAG_ARRAY[@]}"; do
+                    tag=$(echo "$tag" | xargs)
+                    if [ -n "$tag" ]; then
+                      echo "type=raw,value=${tag}" >> $GITHUB_ENV
+                    fi
+                  done
+                fi
+              fi
+            done
+          fi
+
+          echo "EOF" >> $GITHUB_ENV
+
+      - name: Extract metadata (tags, labels) for Docker
+        id: meta
+        uses: docker/metadata-action@v6
+        with:
+          images: ${{ inputs.registry }}/${{ inputs.image-name }}
+          tags: |
+            ${{ env.TAGS_CONFIG }}
+          labels: |
+            ${{ inputs.labels }}
+
+      - name: Build and push Docker Image (single-arch, tagged)
+        if: needs.setup-matrix.outputs.needs_merge != 'true' && !(inputs.cache-from != '' && inputs.cache-to != '')
+        id: build-single
+        uses: docker/build-push-action@v7
+        with:
+          context: ${{ inputs.docker-context }}
+          file: ${{ inputs.docker-file }}
+          tags: ${{ steps.meta.outputs.tags }}
+          labels: ${{ steps.meta.outputs.labels }}
+          build-args: ${{ steps.build-args.outputs.build-args }}
+          no-cache: ${{ inputs.no-cache }}
+          network: ${{ inputs.network }}
+          platforms: ${{ matrix.platform }}
+          secrets: ${{ secrets.docker-secrets }}
+          push: true
+
+      - name: Build and push Docker Image (single-arch, tagged, github registry cache enabled)
+        if: needs.setup-matrix.outputs.needs_merge != 'true' && inputs.cache-from != '' && inputs.cache-to != ''
+        id: build-single-cached
+        uses: docker/build-push-action@v7
+        with:
+          context: ${{ inputs.docker-context }}
+          file: ${{ inputs.docker-file }}
+          tags: ${{ steps.meta.outputs.tags }}
+          labels: ${{ steps.meta.outputs.labels }}
+          build-args: ${{ steps.build-args.outputs.build-args }}
+          no-cache: ${{ inputs.no-cache }}
+          network: ${{ inputs.network }}
+          platforms: ${{ matrix.platform }}
+          secrets: ${{ secrets.docker-secrets }}
+          cache-from: ${{ inputs.cache-from }}
+          cache-to: ${{ inputs.cache-to }}
+          push: true
+
+      - name: Debug no-cache flag (single-arch)
+        if: needs.setup-matrix.outputs.needs_merge != 'true'
+        shell: bash
+        run: |
+          echo "debug.build_step=single-arch"
+          echo "debug.execution_mode=github-runners"
+          echo "debug.no_cache_input=${{ inputs.no-cache }}"
+          echo "debug.registry_mirror_input=${{ inputs.registry-mirror }}"
+          echo "debug.cache_from_set=${{ inputs.cache-from != '' }}"
+          echo "debug.cache_to_set=${{ inputs.cache-to != '' }}"
+
+      - name: Build and push Docker Image (multi-arch, by digest)
+        if: needs.setup-matrix.outputs.needs_merge == 'true' && !(inputs.cache-from != '' && inputs.cache-to != '')
+        id: build-multi
+        uses: docker/build-push-action@v7
+        with:
+          context: ${{ inputs.docker-context }}
+          file: ${{ inputs.docker-file }}
+          tags: ${{ inputs.registry }}/${{ inputs.image-name }}
+          labels: ${{ steps.meta.outputs.labels }}
+          build-args: ${{ steps.build-args.outputs.build-args }}
+          no-cache: ${{ inputs.no-cache }}
+          network: ${{ inputs.network }}
+          platforms: ${{ matrix.platform }}
+          secrets: ${{ secrets.docker-secrets }}
+          outputs: type=image,"name=${{ inputs.registry }}/${{ inputs.image-name }}",push-by-digest=true,name-canonical=true,push=true
+
+      - name: Build and push Docker Image (multi-arch, by digest, github registry cache enabled)
+        if: needs.setup-matrix.outputs.needs_merge == 'true' && inputs.cache-from != '' && inputs.cache-to != ''
+        id: build-multi-cached
+        uses: docker/build-push-action@v7
+        with:
+          context: ${{ inputs.docker-context }}
+          file: ${{ inputs.docker-file }}
+          tags: ${{ inputs.registry }}/${{ inputs.image-name }}
+          labels: ${{ steps.meta.outputs.labels }}
+          build-args: ${{ steps.build-args.outputs.build-args }}
+          no-cache: ${{ inputs.no-cache }}
+          network: ${{ inputs.network }}
+          platforms: ${{ matrix.platform }}
+          secrets: ${{ secrets.docker-secrets }}
+          cache-from: ${{ inputs.cache-from }}
+          cache-to: ${{ inputs.cache-to }}
+          outputs: type=image,"name=${{ inputs.registry }}/${{ inputs.image-name }}",push-by-digest=true,name-canonical=true,push=true
+
+      - name: Debug no-cache flag (multi-arch)
+        if: needs.setup-matrix.outputs.needs_merge == 'true'
+        shell: bash
+        run: |
+          echo "debug.build_step=multi-arch"
+          echo "debug.execution_mode=github-runners"
+          echo "debug.no_cache_input=${{ inputs.no-cache }}"
+          echo "debug.registry_mirror_input=${{ inputs.registry-mirror }}"
+          echo "debug.cache_from_set=${{ inputs.cache-from != '' }}"
+          echo "debug.cache_to_set=${{ inputs.cache-to != '' }}"
+
+      - name: Output image tag (single-arch)
+        if: needs.setup-matrix.outputs.needs_merge != 'true'
+        id: output-image-tag
+        run: |
+          echo "image_tag=${{ steps.meta.outputs.version }}" >> "$GITHUB_OUTPUT"
+
+      - name: Prepare (multi-arch)
+        if: needs.setup-matrix.outputs.needs_merge == 'true'
+        run: |
+          platform=${{ matrix.platform }}
+          echo "PLATFORM_PAIR=${platform//\//-}" >> $GITHUB_ENV
+          image="${{ inputs.image-name }}"
+          echo "IMAGE_NAME=${image//\//-}" >> $GITHUB_ENV
+
+      - name: Export digest (multi-arch)
+        if: needs.setup-matrix.outputs.needs_merge == 'true'
+        run: |
+          mkdir -p ${{ runner.temp }}/digests
+          digest="${{ steps.build-multi.outputs.digest || steps.build-multi-cached.outputs.digest }}"
+          touch "${{ runner.temp }}/digests/${digest#sha256:}"
+
+      - name: Upload digest (multi-arch)
+        if: needs.setup-matrix.outputs.needs_merge == 'true'
+        uses: actions/upload-artifact@v7
+        with:
+          name: arc-digests-${{ github.run_id }}-${{ env.IMAGE_NAME }}-${{ env.PLATFORM_PAIR }}
+          path: ${{ runner.temp }}/digests/*
+          if-no-files-found: error
+          retention-days: 1
+
+  merge:
+    runs-on: ${{ inputs.runner-merge || 'ubuntu-latest' }}
+    if: needs.setup-matrix.outputs.needs_merge == 'true'
+    outputs:
+      image_tag: ${{ steps.output-image-tag.outputs.image_tag }}
+    needs:
+      - setup-matrix
+      - build
+    steps:
+      - name: Prepare
+        run: |
+          image="${{ inputs.image-name }}"
+          echo "IMAGE_NAME=${image//\//-}" >> $GITHUB_ENV
+
+      - name: Download digests
+        uses: actions/download-artifact@v6
+        with:
+          path: ${{ runner.temp }}/digests
+          pattern: arc-digests-${{ github.run_id }}-${{ env.IMAGE_NAME }}-linux-*
+          merge-multiple: true
+
+      - name: Login to GHCR
+        uses: docker/login-action@v4
+        with:
+          registry: ghcr.io
+          username: ${{ github.repository_owner }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v4
+
+      - name: Prepare tag configuration
+        id: tag_config
+        run: |
+          echo "TAGS_CONFIG<<EOF" >> $GITHUB_ENV
+
+          echo "type=raw,value=${{ needs.setup-matrix.outputs.base_tag }}" >> $GITHUB_ENV
+          echo "type=raw,value=${{ needs.setup-matrix.outputs.sha_tag }}" >> $GITHUB_ENV
+
+          if [ -n "${{ inputs.tags }}" ]; then
+            echo "${{ inputs.tags }}" | while IFS= read -r line || [[ -n "$line" ]]; do
+              line=$(echo "$line" | xargs)
+
+              if [ -n "$line" ]; then
+                if [[ "$line" == *"type="* ]]; then
+                  echo "$line" >> $GITHUB_ENV
+                else
+                  IFS=',' read -ra TAG_ARRAY <<< "$line"
+                  for tag in "${TAG_ARRAY[@]}"; do
+                    tag=$(echo "$tag" | xargs)
+                    if [ -n "$tag" ]; then
+                      echo "type=raw,value=${tag}" >> $GITHUB_ENV
+                    fi
+                  done
+                fi
+              fi
+            done
+          fi
+
+          echo "EOF" >> $GITHUB_ENV
+
+      - name: Extract metadata (tags, labels) for Docker
+        id: meta
+        uses: docker/metadata-action@v6
+        with:
+          images: ${{ inputs.registry }}/${{ inputs.image-name }}
+          tags: |
+            ${{ env.TAGS_CONFIG }}
+          labels: |
+            ${{ inputs.labels }}
+
+      - name: Create manifest list and push
+        working-directory: ${{ runner.temp }}/digests
+        run: |
+          docker buildx imagetools create $(jq -cr '.tags | map("-t " + .) | join(" ")' <<< "$DOCKER_METADATA_OUTPUT_JSON") \
+            $(printf '${{ inputs.registry }}/${{ inputs.image-name }}@sha256:%s ' *)
+
+      - name: Inspect image
+        run: |
+          docker buildx imagetools inspect ${{ inputs.registry }}/${{ inputs.image-name }}:${{ steps.meta.outputs.version }}
+
+      - id: output-image-tag
+        run: |
+          echo "image_tag=${{ steps.meta.outputs.version }}" >> "$GITHUB_OUTPUT"

--- a/.github/workflows/build-and-push-docker-image-github-runners.yml
+++ b/.github/workflows/build-and-push-docker-image-github-runners.yml
@@ -194,7 +194,7 @@ jobs:
     needs: setup-matrix
     if: needs.setup-matrix.outputs.matrix != '{"include":[]}'
     strategy:
-      fail-fast: true
+      fail-fast: false
       matrix: ${{ fromJSON(needs.setup-matrix.outputs.matrix) }}
     runs-on: ${{ matrix.runner || 'ubuntu-latest' }}
     outputs:

--- a/.github/workflows/build-and-push-docker-image-self-hosted-buildkit.yml
+++ b/.github/workflows/build-and-push-docker-image-self-hosted-buildkit.yml
@@ -1,0 +1,526 @@
+name: Build and Push Docker Image (Self-hosted BuildKit)
+
+on:
+  workflow_call:
+    inputs:
+      ref:
+        description: "The branch name, tag, or commit SHA to use for the build job."
+        required: false
+        default: ''
+        type: string
+      image-name:
+        type: string
+        default: ${{ github.repository }}
+        description: "The name for the docker image (Default: Repository name)"
+      docker-file:
+        type: string
+        default: Dockerfile
+        description: "The path to the Dockerfile (Default: ./Dockerfile)"
+      docker-context:
+        type: string
+        default: .
+        description: "The context for the Docker build (Default: .)"
+      build-args:
+        type: string
+        description: "List of additional build contexts (e.g., name=path)"
+        required: false
+      labels:
+        type: string
+        description: "Label that should be appended to the image"
+        required: false
+      tags:
+        type: string
+        description: |
+          Tags for the image. Supports flexible formats:
+          - Comma-separated simple tags (e.g., "v1.0,latest,stable")
+          - Full docker/metadata-action tag configuration (e.g., "type=semver,pattern={{version}}")
+          - Mixed format with multiple lines (e.g., "v1.0,stable" on one line and "type=semver,pattern={{version}}" on another)
+        required: false
+      image-tag:
+        type: string
+        default: ''
+        description: "Optional base image tag override (e.g. my-test-tag)"
+      registry:
+        type: string
+        default: ghcr.io
+        description: "The registry to push the image to (Default: ghcr.io)"
+      network:
+        type: string
+        default: default
+        description: "Networking mode for the RUN instructions during build (Default: default)"
+      no-cache:
+        type: boolean
+        default: false
+        description: "Disable Docker layer cache (--no-cache). BuildKit mount caches remain available."
+      cache-from:
+        type: string
+        default: ''
+        description: "Optional explicit buildx cache-from configuration for ARC mode"
+      cache-to:
+        type: string
+        default: ''
+        description: "Optional explicit buildx cache-to configuration for ARC mode"
+      registry-mirror:
+        type: string
+        default: ''
+        description: "Optional registry mirror address (host:port or URL) for ARC/self-hosted builds"
+      arc-registry-cache:
+        type: boolean
+        default: false
+        description: "Enable registry cache import/export in ARC mode. Default false (stateful BuildKit is typically faster without remote cache sync)."
+      runner-amd64:
+        type: string
+        default: ubuntu-24.04
+        description: "Runner to use for linux/amd64 builds"
+      runner-arm64:
+        type: string
+        default: ubuntu-24.04-arm
+        description: "Runner to use for linux/arm64 builds"
+      runner-merge:
+        type: string
+        default: ubuntu-latest
+        description: "Runner to use for the merge job (default: ubuntu-latest)"
+      build-amd64:
+        type: boolean
+        default: true
+        description: "Enable AMD64 build (default: true)"
+      build-arm64:
+        type: boolean
+        default: true
+        description: "Enable ARM64 build (default: true)"
+    outputs:
+      image_tag:
+        description: "The tag of the image that was built"
+        value: ${{ jobs.merge.outputs.image_tag || jobs.build.outputs.image_tag }}
+      base_tag:
+        description: "Derived base Docker tag"
+        value: ${{ jobs.setup-matrix.outputs.base_tag }}
+      sha_tag:
+        description: "Derived immutable Docker tag with short SHA suffix"
+        value: ${{ jobs.setup-matrix.outputs.sha_tag }}
+      cache_tag:
+        description: "Derived cache tag namespace"
+        value: ${{ jobs.setup-matrix.outputs.cache_tag }}
+      image_repo:
+        description: "Lower-cased owner/repository name"
+        value: ${{ jobs.setup-matrix.outputs.image_repo }}
+
+    secrets:
+      registry-user:
+        required: false
+      registry-password:
+        required: false
+      docker-secrets:
+        required: false
+        description: "Secrets to pass to Docker build (e.g., 'SECRET_NAME=secret_value')"
+
+jobs:
+  setup-matrix:
+    runs-on: ${{ inputs.runner-merge || 'ubuntu-latest' }}
+    outputs:
+      matrix: ${{ steps.setup.outputs.matrix }}
+      needs_merge: ${{ steps.setup.outputs.needs_merge }}
+      base_tag: ${{ steps.setup.outputs.base_tag }}
+      sha_tag: ${{ steps.setup.outputs.sha_tag }}
+      cache_tag: ${{ steps.setup.outputs.cache_tag }}
+      image_repo: ${{ steps.setup.outputs.image_repo }}
+    steps:
+      - id: setup
+        shell: bash
+        run: |
+          set -euo pipefail
+
+          SHORT_SHA="${GITHUB_SHA::7}"
+          REF_NAME="${GITHUB_REF_NAME}"
+          SAFE_REF_NAME=$(echo "${REF_NAME}" | tr '[:upper:]' '[:lower:]' | tr -c 'a-z0-9_.-' '-')
+          IMAGE_REPO=$(echo "${GITHUB_REPOSITORY}" | tr '[:upper:]' '[:lower:]')
+
+          OVERRIDE="${{ inputs.image-tag }}"
+          PR_NUMBER="${{ github.event.pull_request.number || '' }}"
+          RELEASE_TAG="${{ github.event.release.tag_name || '' }}"
+          if [[ -n "${OVERRIDE}" ]]; then
+            BASE_TAG="${OVERRIDE}"
+          elif [[ "${GITHUB_EVENT_NAME}" == "pull_request" ]]; then
+            if [[ -z "${PR_NUMBER}" ]]; then
+              echo "::error::pull_request event detected but PR number is missing"
+              exit 1
+            fi
+            BASE_TAG="pr-${PR_NUMBER}"
+          elif [[ "${GITHUB_EVENT_NAME}" == "release" ]]; then
+            if [[ -n "${RELEASE_TAG}" ]]; then
+              BASE_TAG=$(echo "${RELEASE_TAG}" | tr '[:upper:]' '[:lower:]' | tr -c 'a-z0-9_.-' '-')
+            else
+              BASE_TAG="${SAFE_REF_NAME}"
+            fi
+          elif [[ "${GITHUB_REF}" == "refs/heads/main" || "${GITHUB_REF}" == "refs/heads/master" ]]; then
+            BASE_TAG="latest"
+          else
+            BASE_TAG="${SAFE_REF_NAME}"
+          fi
+
+          if [[ "${GITHUB_EVENT_NAME}" == "pull_request" ]]; then
+            CACHE_TAG="build-cache-pr-${PR_NUMBER}"
+          elif [[ "${BASE_TAG}" == "latest" ]]; then
+            CACHE_TAG="build-cache"
+          else
+            CACHE_TAG="build-cache-${BASE_TAG}"
+          fi
+
+          MATRIX='{"include":['
+          PLATFORMS=()
+
+          if [[ "${{ inputs.build-amd64 }}" == "true" ]]; then
+            PLATFORMS+=('{"platform":"linux/amd64","runner":"${{ inputs.runner-amd64 }}"}')
+          fi
+
+          if [[ "${{ inputs.build-arm64 }}" == "true" ]]; then
+            PLATFORMS+=('{"platform":"linux/arm64","runner":"${{ inputs.runner-arm64 }}"}')
+          fi
+
+          JOINED=$(IFS=,; echo "${PLATFORMS[*]}")
+          MATRIX="${MATRIX}${JOINED}]}"
+
+          if [[ ${#PLATFORMS[@]} -gt 1 ]]; then
+            NEEDS_MERGE="true"
+          else
+            NEEDS_MERGE="false"
+          fi
+
+          echo "base_tag=${BASE_TAG}" >> "$GITHUB_OUTPUT"
+          echo "sha_tag=${BASE_TAG}-${SHORT_SHA}" >> "$GITHUB_OUTPUT"
+          echo "cache_tag=${CACHE_TAG}" >> "$GITHUB_OUTPUT"
+          echo "image_repo=${IMAGE_REPO}" >> "$GITHUB_OUTPUT"
+          echo "matrix=${MATRIX}" >> "$GITHUB_OUTPUT"
+          echo "needs_merge=${NEEDS_MERGE}" >> "$GITHUB_OUTPUT"
+
+  build:
+    name: Build ${{ matrix.platform }} Docker Image for ${{ inputs.image-name }}
+    needs: setup-matrix
+    if: needs.setup-matrix.outputs.matrix != '{"include":[]}'
+    strategy:
+      fail-fast: true
+      matrix: ${{ fromJSON(needs.setup-matrix.outputs.matrix) }}
+    runs-on: ${{ matrix.runner || 'ubuntu-latest' }}
+    outputs:
+      image_tag: ${{ steps.output-image-tag.outputs.image_tag }}
+    steps:
+      - name: Git Checkout (specific ref)
+        uses: actions/checkout@v6
+        if: ${{ inputs.ref != '' }}
+        with:
+          ref: ${{ inputs.ref }}
+      - name: Git Checkout (default)
+        uses: actions/checkout@v6
+        if: ${{ inputs.ref == '' }}
+        with:
+          fetch-depth: 1
+
+      - name: Compute BuildKit worker endpoint
+        id: buildkit-route
+        shell: bash
+        run: |
+          set -euo pipefail
+          NUM_WORKERS="${BUILDKIT_NUM_WORKERS:-}"
+          BK_NAMESPACE="${BUILDKIT_NAMESPACE:-}"
+          if [[ -z "${NUM_WORKERS}" || "${NUM_WORKERS}" == "0" ]]; then
+            echo "::error::BUILDKIT_NUM_WORKERS is not set. Is this job running on arc-runner-set-buildkit-exp?"
+            exit 1
+          fi
+          if [[ -z "${BK_NAMESPACE}" ]]; then
+            echo "::error::BUILDKIT_NAMESPACE is not set. Is this job running on arc-runner-set-buildkit-exp?"
+            exit 1
+          fi
+          HASH_INPUT="${{ github.repository }}::${{ inputs.docker-file }}"
+          WORKER_ID=$(echo -n "${HASH_INPUT}" | cksum | awk "{print \$1 % ${NUM_WORKERS}}")
+          ADDR="tcp://buildkitd-${WORKER_ID}.buildkitd.${BK_NAMESPACE}.svc.cluster.local:1234"
+          echo "endpoint=${ADDR}" >> "${GITHUB_OUTPUT}"
+          echo "BuildKit routing: '${HASH_INPUT}' → buildkitd-${WORKER_ID} @ ${ADDR}"
+
+      - name: Install Docker Buildx (remote)
+        id: setup-buildx-remote
+        uses: docker/setup-buildx-action@v4
+        with:
+          driver: remote
+          endpoint: ${{ steps.buildkit-route.outputs.endpoint }}
+
+      - name: Prepare build args
+        id: build-args
+        run: |
+          BUILD_ARGS="${{ inputs.build-args }}"
+
+          echo "build-args<<EOF" >> $GITHUB_OUTPUT
+          echo "$BUILD_ARGS" >> $GITHUB_OUTPUT
+          echo "EOF" >> $GITHUB_OUTPUT
+
+      - name: Determine registry mirror (ARC default)
+        id: mirror
+        shell: bash
+        run: |
+          set -euo pipefail
+          CANDIDATE="${{ inputs.registry-mirror }}"
+          if [[ -z "${CANDIDATE}" ]]; then
+            CANDIDATE="131.159.88.117:30081"
+          fi
+          NORMALIZED="${CANDIDATE#http://}"
+          NORMALIZED="${NORMALIZED#https://}"
+          echo "mirror_hostport=${NORMALIZED}" >> "$GITHUB_OUTPUT"
+          echo "mirror_url=http://${NORMALIZED}" >> "$GITHUB_OUTPUT"
+
+      - name: Login to registry mirror
+        uses: docker/login-action@v4
+        with:
+          registry: ${{ steps.mirror.outputs.mirror_hostport }}
+          username: ${{ secrets.registry-user || github.actor }}
+          password: ${{ secrets.registry-password || secrets.GITHUB_TOKEN }}
+
+      - name: Log in to the Container registry
+        uses: docker/login-action@v4
+        with:
+          registry: ${{ inputs.registry }}
+          username: ${{ secrets.registry-user || github.actor }}
+          password: ${{ secrets.registry-password || secrets.GITHUB_TOKEN }}
+
+      - name: Prepare tag configuration
+        id: tag_config
+        run: |
+          echo "TAGS_CONFIG<<EOF" >> $GITHUB_ENV
+
+          echo "type=raw,value=${{ needs.setup-matrix.outputs.base_tag }}" >> $GITHUB_ENV
+          echo "type=raw,value=${{ needs.setup-matrix.outputs.sha_tag }}" >> $GITHUB_ENV
+
+          if [ -n "${{ inputs.tags }}" ]; then
+            echo "${{ inputs.tags }}" | while IFS= read -r line || [[ -n "$line" ]]; do
+              line=$(echo "$line" | xargs)
+
+              if [ -n "$line" ]; then
+                if [[ "$line" == *"type="* ]]; then
+                  echo "$line" >> $GITHUB_ENV
+                else
+                  IFS=',' read -ra TAG_ARRAY <<< "$line"
+                  for tag in "${TAG_ARRAY[@]}"; do
+                    tag=$(echo "$tag" | xargs)
+                    if [ -n "$tag" ]; then
+                      echo "type=raw,value=${tag}" >> $GITHUB_ENV
+                    fi
+                  done
+                fi
+              fi
+            done
+          fi
+
+          echo "EOF" >> $GITHUB_ENV
+
+      - name: Extract metadata (tags, labels) for Docker
+        id: meta
+        uses: docker/metadata-action@v6
+        with:
+          images: ${{ inputs.registry }}/${{ inputs.image-name }}
+          tags: |
+            ${{ env.TAGS_CONFIG }}
+          labels: |
+            ${{ inputs.labels }}
+
+      - name: Build and push Docker Image (single-arch, tagged)
+        if: needs.setup-matrix.outputs.needs_merge != 'true' && inputs.arc-registry-cache != true
+        id: build-single
+        uses: docker/build-push-action@v7
+        with:
+          context: ${{ inputs.docker-context }}
+          file: ${{ inputs.docker-file }}
+          tags: ${{ steps.meta.outputs.tags }}
+          labels: ${{ steps.meta.outputs.labels }}
+          build-args: ${{ steps.build-args.outputs.build-args }}
+          no-cache: ${{ inputs.no-cache }}
+          network: ${{ inputs.network }}
+          platforms: ${{ matrix.platform }}
+          secrets: ${{ secrets.docker-secrets }}
+          push: true
+
+      - name: Debug no-cache flag (single-arch)
+        if: needs.setup-matrix.outputs.needs_merge != 'true'
+        shell: bash
+        run: |
+          echo "debug.build_step=single-arch"
+          echo "debug.execution_mode=self-hosted-buildkit"
+          echo "debug.no_cache_input=${{ inputs.no-cache }}"
+          echo "debug.arc_registry_cache=${{ inputs.arc-registry-cache }}"
+          echo "debug.cache_from_set=${{ inputs.cache-from != '' }}"
+          echo "debug.cache_to_set=${{ inputs.cache-to != '' }}"
+
+      - name: Build and push Docker Image (single-arch, tagged, ARC registry cache enabled)
+        if: needs.setup-matrix.outputs.needs_merge != 'true' && inputs.arc-registry-cache == true
+        id: build-single-cached
+        uses: docker/build-push-action@v7
+        with:
+          context: ${{ inputs.docker-context }}
+          file: ${{ inputs.docker-file }}
+          tags: ${{ steps.meta.outputs.tags }}
+          labels: ${{ steps.meta.outputs.labels }}
+          build-args: ${{ steps.build-args.outputs.build-args }}
+          no-cache: ${{ inputs.no-cache }}
+          network: ${{ inputs.network }}
+          platforms: ${{ matrix.platform }}
+          secrets: ${{ secrets.docker-secrets }}
+          cache-from: ${{ inputs.cache-from != '' && inputs.cache-from || format('type=registry,ref={0}/{1}:{2},registry.insecure=true', steps.mirror.outputs.mirror_hostport, needs.setup-matrix.outputs.image_repo, needs.setup-matrix.outputs.cache_tag) }}
+          cache-to: ${{ inputs.cache-to != '' && inputs.cache-to || format('type=registry,ref={0}/{1}:{2},mode=max,image-manifest=true,oci-mediatypes=true,registry.insecure=true', steps.mirror.outputs.mirror_hostport, needs.setup-matrix.outputs.image_repo, needs.setup-matrix.outputs.cache_tag) }}
+          push: true
+
+      - name: Build and push Docker Image (multi-arch, by digest)
+        if: needs.setup-matrix.outputs.needs_merge == 'true' && inputs.arc-registry-cache != true
+        id: build-multi
+        uses: docker/build-push-action@v7
+        with:
+          context: ${{ inputs.docker-context }}
+          file: ${{ inputs.docker-file }}
+          tags: ${{ inputs.registry }}/${{ inputs.image-name }}
+          labels: ${{ steps.meta.outputs.labels }}
+          build-args: ${{ steps.build-args.outputs.build-args }}
+          no-cache: ${{ inputs.no-cache }}
+          network: ${{ inputs.network }}
+          platforms: ${{ matrix.platform }}
+          secrets: ${{ secrets.docker-secrets }}
+          outputs: type=image,"name=${{ inputs.registry }}/${{ inputs.image-name }}",push-by-digest=true,name-canonical=true,push=true
+
+      - name: Build and push Docker Image (multi-arch, by digest, ARC registry cache enabled)
+        if: needs.setup-matrix.outputs.needs_merge == 'true' && inputs.arc-registry-cache == true
+        id: build-multi-cached
+        uses: docker/build-push-action@v7
+        with:
+          context: ${{ inputs.docker-context }}
+          file: ${{ inputs.docker-file }}
+          tags: ${{ inputs.registry }}/${{ inputs.image-name }}
+          labels: ${{ steps.meta.outputs.labels }}
+          build-args: ${{ steps.build-args.outputs.build-args }}
+          no-cache: ${{ inputs.no-cache }}
+          network: ${{ inputs.network }}
+          platforms: ${{ matrix.platform }}
+          secrets: ${{ secrets.docker-secrets }}
+          cache-from: ${{ inputs.cache-from != '' && inputs.cache-from || format('type=registry,ref={0}/{1}:{2},registry.insecure=true', steps.mirror.outputs.mirror_hostport, needs.setup-matrix.outputs.image_repo, needs.setup-matrix.outputs.cache_tag) }}
+          cache-to: ${{ inputs.cache-to != '' && inputs.cache-to || format('type=registry,ref={0}/{1}:{2},mode=max,image-manifest=true,oci-mediatypes=true,registry.insecure=true', steps.mirror.outputs.mirror_hostport, needs.setup-matrix.outputs.image_repo, needs.setup-matrix.outputs.cache_tag) }}
+          outputs: type=image,"name=${{ inputs.registry }}/${{ inputs.image-name }}",push-by-digest=true,name-canonical=true,push=true
+
+      - name: Debug no-cache flag (multi-arch)
+        if: needs.setup-matrix.outputs.needs_merge == 'true'
+        shell: bash
+        run: |
+          echo "debug.build_step=multi-arch"
+          echo "debug.execution_mode=self-hosted-buildkit"
+          echo "debug.no_cache_input=${{ inputs.no-cache }}"
+          echo "debug.arc_registry_cache=${{ inputs.arc-registry-cache }}"
+          echo "debug.cache_from_set=${{ inputs.cache-from != '' }}"
+          echo "debug.cache_to_set=${{ inputs.cache-to != '' }}"
+
+      - name: Output image tag (single-arch)
+        if: needs.setup-matrix.outputs.needs_merge != 'true'
+        id: output-image-tag
+        run: |
+          echo "image_tag=${{ steps.meta.outputs.version }}" >> "$GITHUB_OUTPUT"
+
+      - name: Prepare (multi-arch)
+        if: needs.setup-matrix.outputs.needs_merge == 'true'
+        run: |
+          platform=${{ matrix.platform }}
+          echo "PLATFORM_PAIR=${platform//\//-}" >> $GITHUB_ENV
+          image="${{ inputs.image-name }}"
+          echo "IMAGE_NAME=${image//\//-}" >> $GITHUB_ENV
+
+      - name: Export digest (multi-arch)
+        if: needs.setup-matrix.outputs.needs_merge == 'true'
+        run: |
+          mkdir -p ${{ runner.temp }}/digests
+          digest="${{ steps.build-multi.outputs.digest || steps.build-multi-cached.outputs.digest }}"
+          touch "${{ runner.temp }}/digests/${digest#sha256:}"
+
+      - name: Upload digest (multi-arch)
+        if: needs.setup-matrix.outputs.needs_merge == 'true'
+        uses: actions/upload-artifact@v7
+        with:
+          name: arc-digests-${{ github.run_id }}-${{ env.IMAGE_NAME }}-${{ env.PLATFORM_PAIR }}
+          path: ${{ runner.temp }}/digests/*
+          if-no-files-found: error
+          retention-days: 1
+
+  merge:
+    runs-on: ${{ inputs.runner-merge || 'ubuntu-latest' }}
+    if: needs.setup-matrix.outputs.needs_merge == 'true'
+    outputs:
+      image_tag: ${{ steps.output-image-tag.outputs.image_tag }}
+    needs:
+      - setup-matrix
+      - build
+    steps:
+      - name: Prepare
+        run: |
+          image="${{ inputs.image-name }}"
+          echo "IMAGE_NAME=${image//\//-}" >> $GITHUB_ENV
+
+      - name: Download digests
+        uses: actions/download-artifact@v6
+        with:
+          path: ${{ runner.temp }}/digests
+          pattern: arc-digests-${{ github.run_id }}-${{ env.IMAGE_NAME }}-linux-*
+          merge-multiple: true
+
+      - name: Login to GHCR
+        uses: docker/login-action@v4
+        with:
+          registry: ghcr.io
+          username: ${{ github.repository_owner }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v4
+
+      - name: Prepare tag configuration
+        id: tag_config
+        run: |
+          echo "TAGS_CONFIG<<EOF" >> $GITHUB_ENV
+
+          echo "type=raw,value=${{ needs.setup-matrix.outputs.base_tag }}" >> $GITHUB_ENV
+          echo "type=raw,value=${{ needs.setup-matrix.outputs.sha_tag }}" >> $GITHUB_ENV
+
+          if [ -n "${{ inputs.tags }}" ]; then
+            echo "${{ inputs.tags }}" | while IFS= read -r line || [[ -n "$line" ]]; do
+              line=$(echo "$line" | xargs)
+
+              if [ -n "$line" ]; then
+                if [[ "$line" == *"type="* ]]; then
+                  echo "$line" >> $GITHUB_ENV
+                else
+                  IFS=',' read -ra TAG_ARRAY <<< "$line"
+                  for tag in "${TAG_ARRAY[@]}"; do
+                    tag=$(echo "$tag" | xargs)
+                    if [ -n "$tag" ]; then
+                      echo "type=raw,value=${tag}" >> $GITHUB_ENV
+                    fi
+                  done
+                fi
+              fi
+            done
+          fi
+
+          echo "EOF" >> $GITHUB_ENV
+
+      - name: Extract metadata (tags, labels) for Docker
+        id: meta
+        uses: docker/metadata-action@v6
+        with:
+          images: ${{ inputs.registry }}/${{ inputs.image-name }}
+          tags: |
+            ${{ env.TAGS_CONFIG }}
+          labels: |
+            ${{ inputs.labels }}
+
+      - name: Create manifest list and push
+        working-directory: ${{ runner.temp }}/digests
+        run: |
+          docker buildx imagetools create $(jq -cr '.tags | map("-t " + .) | join(" ")' <<< "$DOCKER_METADATA_OUTPUT_JSON") \
+            $(printf '${{ inputs.registry }}/${{ inputs.image-name }}@sha256:%s ' *)
+
+      - name: Inspect image
+        run: |
+          docker buildx imagetools inspect ${{ inputs.registry }}/${{ inputs.image-name }}:${{ steps.meta.outputs.version }}
+
+      - id: output-image-tag
+        run: |
+          echo "image_tag=${{ steps.meta.outputs.version }}" >> "$GITHUB_OUTPUT"

--- a/.github/workflows/build-and-push-docker-image-self-hosted-buildkit.yml
+++ b/.github/workflows/build-and-push-docker-image-self-hosted-buildkit.yml
@@ -461,6 +461,26 @@ jobs:
           pattern: arc-digests-${{ github.run_id }}-${{ env.IMAGE_NAME }}-linux-*
           merge-multiple: true
 
+      - name: Determine registry mirror (ARC default)
+        id: merge-mirror
+        shell: bash
+        run: |
+          set -euo pipefail
+          CANDIDATE="${{ inputs.registry-mirror }}"
+          if [[ -z "${CANDIDATE}" ]]; then
+            CANDIDATE="131.159.88.117:30081"
+          fi
+          NORMALIZED="${CANDIDATE#http://}"
+          NORMALIZED="${NORMALIZED#https://}"
+          echo "mirror_hostport=${NORMALIZED}" >> "$GITHUB_OUTPUT"
+
+      - name: Login to registry mirror
+        uses: docker/login-action@v4
+        with:
+          registry: ${{ steps.merge-mirror.outputs.mirror_hostport }}
+          username: ${{ secrets.registry-user || github.actor }}
+          password: ${{ secrets.registry-password || secrets.GITHUB_TOKEN }}
+
       - name: Login to GHCR
         uses: docker/login-action@v4
         with:
@@ -470,6 +490,13 @@ jobs:
 
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v4
+        with:
+          buildkitd-config-inline: |
+            [registry."docker.io"]
+              mirrors = ["${{ steps.merge-mirror.outputs.mirror_hostport }}"]
+            [registry."${{ steps.merge-mirror.outputs.mirror_hostport }}"]
+              http = true
+              insecure = true
 
       - name: Prepare tag configuration
         id: tag_config

--- a/.github/workflows/build-and-push-docker-image-self-hosted-buildkit.yml
+++ b/.github/workflows/build-and-push-docker-image-self-hosted-buildkit.yml
@@ -267,6 +267,7 @@ jobs:
           echo "mirror_url=http://${NORMALIZED}" >> "$GITHUB_OUTPUT"
 
       - name: Login to registry mirror
+        if: ${{ inputs.registry-mirror != '' && startsWith(inputs.registry-mirror, 'https://') }}
         uses: docker/login-action@v4
         with:
           registry: ${{ steps.mirror.outputs.mirror_hostport }}
@@ -475,6 +476,7 @@ jobs:
           echo "mirror_hostport=${NORMALIZED}" >> "$GITHUB_OUTPUT"
 
       - name: Login to registry mirror
+        if: ${{ inputs.registry-mirror != '' && startsWith(inputs.registry-mirror, 'https://') }}
         uses: docker/login-action@v4
         with:
           registry: ${{ steps.merge-mirror.outputs.mirror_hostport }}

--- a/.github/workflows/build-and-push-docker-image-self-hosted-buildkit.yml
+++ b/.github/workflows/build-and-push-docker-image-self-hosted-buildkit.yml
@@ -198,7 +198,7 @@ jobs:
     needs: setup-matrix
     if: needs.setup-matrix.outputs.matrix != '{"include":[]}'
     strategy:
-      fail-fast: true
+      fail-fast: false
       matrix: ${{ fromJSON(needs.setup-matrix.outputs.matrix) }}
     runs-on: ${{ matrix.runner || 'ubuntu-latest' }}
     outputs:

--- a/.github/workflows/build-and-push-docker-image.yml
+++ b/.github/workflows/build-and-push-docker-image.yml
@@ -126,9 +126,9 @@ jobs:
       cache-to: ${{ inputs.cache-to }}
       registry-mirror: ${{ inputs.registry-mirror }}
       arc-registry-cache: ${{ inputs.arc-registry-cache }}
-      runner-amd64: arc-buildkit-eduide-theiaprod-amd64
+      runner-amd64: arc-buildkit-eduide-stud-amd64
       runner-arm64: arc-buildkit-eduide-parma-arm64
-      runner-merge: arc-buildkit-eduide-theiaprod-amd64
+      runner-merge: arc-buildkit-eduide-stud-amd64
       build-amd64: ${{ inputs.build-amd64 }}
       build-arm64: ${{ inputs.build-arm64 }}
     secrets:

--- a/.github/workflows/build-and-push-docker-image.yml
+++ b/.github/workflows/build-and-push-docker-image.yml
@@ -126,9 +126,9 @@ jobs:
       cache-to: ${{ inputs.cache-to }}
       registry-mirror: ${{ inputs.registry-mirror }}
       arc-registry-cache: ${{ inputs.arc-registry-cache }}
-      runner-amd64: arc-buildkit-eduide-amd64
-      runner-arm64: arc-buildkit-eduide-arm64
-      runner-merge: arc-buildkit-eduide-amd64
+      runner-amd64: arc-buildkit-eduide-theiaprod-amd64
+      runner-arm64: arc-buildkit-eduide-parma-arm64
+      runner-merge: arc-buildkit-eduide-theiaprod-amd64
       build-amd64: ${{ inputs.build-amd64 }}
       build-arm64: ${{ inputs.build-arm64 }}
     secrets:

--- a/.github/workflows/build-and-push-docker-image.yml
+++ b/.github/workflows/build-and-push-docker-image.yml
@@ -36,6 +36,10 @@ on:
           - Full docker/metadata-action tag configuration (e.g., "type=semver,pattern={{version}}")
           - Mixed format with multiple lines (e.g., "v1.0,stable" on one line and "type=semver,pattern={{version}}" on another)
         required: false
+      image-tag:
+        type: string
+        default: ''
+        description: "Optional base image tag override (e.g. my-test-tag)"
       registry:
         type: string
         default: ghcr.io
@@ -44,191 +48,118 @@ on:
         type: string
         default: default
         description: "Networking mode for the RUN instructions during build (Default: default)"
+      no-cache:
+        type: boolean
+        default: false
+        description: "Disable Docker layer cache (--no-cache). BuildKit mount caches remain available."
+      cache-from:
+        type: string
+        default: ''
+        description: "Optional buildx cache-from configuration. When set together with cache-to, github-runners mode uses registry cache import."
+      cache-to:
+        type: string
+        default: ''
+        description: "Optional buildx cache-to configuration. When set together with cache-from, github-runners mode uses registry cache export."
+      registry-mirror:
+        type: string
+        default: ''
+        description: "Optional mirror endpoint (host:port or URL). In self-hosted-buildkit mode, defaults to Zot if unset"
+      arc-registry-cache:
+        type: boolean
+        default: false
+        description: "Enable registry cache import/export in self-hosted-buildkit (ARC) mode. Default false because ARC stateful BuildKit is usually faster without remote cache sync."
+      build-amd64:
+        type: boolean
+        default: true
+        description: "Enable AMD64 build (default: true)"
+      build-arm64:
+        type: boolean
+        default: true
+        description: "Enable ARM64 build (default: true)"
+      execution-mode:
+        type: string
+        default: ''
+        description: "Execution mode input. Only 3 supported operating options overall: auto-routing, self-hosted-buildkit, github-runners. This input accepts self-hosted-buildkit or github-runners."
     outputs:
-      image_tag: 
+      image_tag:
         description: "The tag of the image that was built"
-        value: ${{ jobs.merge.outputs.image_tag }}
-    
+        value: ${{ jobs.self-hosted-buildkit.outputs.image_tag || jobs.github-runners.outputs.image_tag }}
+      base_tag:
+        description: "Derived base Docker tag"
+        value: ${{ jobs.self-hosted-buildkit.outputs.base_tag || jobs.github-runners.outputs.base_tag }}
+      sha_tag:
+        description: "Derived immutable Docker tag with short SHA suffix"
+        value: ${{ jobs.self-hosted-buildkit.outputs.sha_tag || jobs.github-runners.outputs.sha_tag }}
+      cache_tag:
+        description: "Derived cache tag namespace"
+        value: ${{ jobs.self-hosted-buildkit.outputs.cache_tag || jobs.github-runners.outputs.cache_tag }}
+      image_repo:
+        description: "Lower-cased owner/repository name"
+        value: ${{ jobs.self-hosted-buildkit.outputs.image_repo || jobs.github-runners.outputs.image_repo }}
+
     secrets:
       registry-user:
         required: false
       registry-password:
         required: false
+      docker-secrets:
+        required: false
+        description: "Secrets to pass to Docker build (e.g., 'SECRET_NAME=secret_value')"
 
 jobs:
-  build:
-    name: Build ${{ matrix.platform }} Docker Image for ${{ inputs.image-name }}
-    strategy:
-      fail-fast: true
-      matrix:
-        include:
-          - platform: linux/amd64
-            runner: ubuntu-24.04
-          - platform: linux/arm64
-            runner: ubuntu-24.04-arm
-    runs-on: ${{ matrix.runner || 'ubuntu-latest' }}
-    steps:
-      # Git Checkout
-      - name: Git Checkout (specific ref)
-        uses: actions/checkout@v6
-        if: ${{ inputs.ref != '' }}
-        with:
-          ref: ${{ inputs.ref }}
-      - name: Git Checkout (default)
-        uses: actions/checkout@v6
-        if: ${{ inputs.ref == '' }}
-        with:
-          fetch-depth: 1
+  self-hosted-buildkit:
+    if: ${{ inputs.execution-mode == 'self-hosted-buildkit' }}
+    uses: ./.github/workflows/build-and-push-docker-image-self-hosted-buildkit.yml
+    with:
+      ref: ${{ inputs.ref }}
+      image-name: ${{ inputs.image-name }}
+      docker-file: ${{ inputs.docker-file }}
+      docker-context: ${{ inputs.docker-context }}
+      build-args: ${{ inputs.build-args }}
+      labels: ${{ inputs.labels }}
+      tags: ${{ inputs.tags }}
+      image-tag: ${{ inputs.image-tag }}
+      registry: ${{ inputs.registry }}
+      network: ${{ inputs.network }}
+      no-cache: ${{ inputs.no-cache }}
+      cache-from: ${{ inputs.cache-from }}
+      cache-to: ${{ inputs.cache-to }}
+      registry-mirror: ${{ inputs.registry-mirror }}
+      arc-registry-cache: ${{ inputs.arc-registry-cache }}
+      runner-amd64: arc-buildkit-eduide-amd64
+      runner-arm64: arc-buildkit-eduide-arm64
+      runner-merge: arc-buildkit-eduide-amd64
+      build-amd64: ${{ inputs.build-amd64 }}
+      build-arm64: ${{ inputs.build-arm64 }}
+    secrets:
+      registry-user: ${{ secrets.registry-user }}
+      registry-password: ${{ secrets.registry-password }}
+      docker-secrets: ${{ secrets.docker-secrets }}
 
-      - name: Set up QEMU
-        uses: docker/setup-qemu-action@v3
-        with:
-          platforms: all
-  
-      - name: Install Docker Buildx
-        uses: docker/setup-buildx-action@v3
-        with:
-          driver-opts: "network=${{ inputs.network }}"
-          buildkitd-config-inline: |
-            [registry."docker.io"]
-              mirrors = ["https://docker-mirror.ase.in.tum.de:8765"]
-
-      - name: Log in to the Container registry
-        uses: docker/login-action@v4
-        with:
-          registry: ${{ inputs.registry }}
-          username: ${{ secrets.registry-user || github.actor }}
-          password: ${{ secrets.registry-password || secrets.GITHUB_TOKEN }}
-
-      - name: Extract metadata (tags, labels) for Docker
-        id: meta
-        uses: docker/metadata-action@v5
-        with:
-          images: ${{ inputs.registry }}/${{ inputs.image-name }}
-
-      - name: Build and push Docker Image
-        id: build
-        uses: docker/build-push-action@v7
-        with:
-          context: ${{ inputs.docker-context }}
-          file: ${{ inputs.docker-file }}
-          tags: ${{ inputs.registry }}/${{ inputs.image-name }}
-          labels: ${{ steps.meta.outputs.labels }}
-          build-args: ${{ inputs.build-args }}
-          network: ${{ inputs.network }}
-          outputs: type=image,"name=${{ inputs.registry }}/${{ inputs.image-name }}",push-by-digest=true,name-canonical=true,push=true
-
-      - name: Prepare
-        run: |
-          platform=${{ matrix.platform }}
-          echo "PLATFORM_PAIR=${platform//\//-}" >> $GITHUB_ENV
-          image="${{ inputs.image-name }}"
-          echo "IMAGE_NAME=${image//\//-}" >> $GITHUB_ENV
-
-      - name: Export digest
-        run: |
-          mkdir -p ${{ runner.temp }}/digests
-          digest="${{ steps.build.outputs.digest }}"
-          touch "${{ runner.temp }}/digests/${digest#sha256:}"          
-  
-      - name: Upload digest
-        uses: actions/upload-artifact@v7
-        with:
-          name: digests-${{ github.run_id }}-${{ env.IMAGE_NAME }}-${{ env.PLATFORM_PAIR }}
-          path: ${{ runner.temp }}/digests/*
-          if-no-files-found: error
-          retention-days: 1
-
-  merge:
-    runs-on: ubuntu-latest
-    outputs: 
-      image_tag: ${{ steps.output-image-tag.outputs.image_tag }}
-    needs:
-      - build
-    steps:
-      - name: Prepare
-        run: |
-          image="${{ inputs.image-name }}"
-          echo "IMAGE_NAME=${image//\//-}" >> $GITHUB_ENV
-
-      - name: Download digests
-        uses: actions/download-artifact@v8
-        with:
-          path: ${{ runner.temp }}/digests
-          pattern: digests-${{ github.run_id }}-${{ env.IMAGE_NAME }}-linux-*
-          merge-multiple: true
-
-      - name: Login to GHCR
-        uses: docker/login-action@v4
-        with:
-          registry: ghcr.io
-          username: ${{ github.repository_owner }}
-          password: ${{ secrets.GITHUB_TOKEN }}
-
-      - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@v3
-
-      # Process tags input to support both simple tags and advanced configuration
-      - name: Prepare tag configuration
-        id: tag_config
-        run: |
-          # Use TAGS_CONFIG environment variable to store tags configuration
-          echo "TAGS_CONFIG<<EOF" >> $GITHUB_ENV
-          
-          # Default tagging configuration
-          echo "type=raw,value=latest,enable={{is_default_branch}}" >> $GITHUB_ENV
-          echo "type=ref,event=branch" >> $GITHUB_ENV
-          echo "type=ref,event=pr" >> $GITHUB_ENV
-          
-          # Check if tags input is provided
-          if [ -n "${{ inputs.tags }}" ]; then
-            # Process input line by line
-            echo "${{ inputs.tags }}" | while IFS= read -r line || [[ -n "$line" ]]; do
-              # Trim whitespace
-              line=$(echo "$line" | xargs)
-          
-              if [ -n "$line" ]; then
-                if [[ "$line" == *"type="* ]]; then
-                  # Line contains configuration, add it directly
-                  echo "$line" >> $GITHUB_ENV
-                else
-                  # Line contains simple tags, process as comma-separated list
-                  IFS=',' read -ra TAG_ARRAY <<< "$line"
-                  for tag in "${TAG_ARRAY[@]}"; do
-                    # Trim whitespace from each tag
-                    tag=$(echo "$tag" | xargs)
-                    if [ -n "$tag" ]; then
-                      echo "type=raw,value=${tag}" >> $GITHUB_ENV
-                    fi
-                  done
-                fi
-              fi
-            done
-          fi
-          
-          echo "EOF" >> $GITHUB_ENV
-
-
-      - name: Extract metadata (tags, labels) for Docker
-        id: meta
-        uses: docker/metadata-action@v5
-        with:
-          images: ${{ inputs.registry }}/${{ inputs.image-name }}
-          tags: |
-            ${{ env.TAGS_CONFIG }}
-          labels: |
-            ${{ inputs.labels }}        
-
-      - name: Create manifest list and push
-        working-directory: ${{ runner.temp }}/digests
-        run: |
-          docker buildx imagetools create $(jq -cr '.tags | map("-t " + .) | join(" ")' <<< "$DOCKER_METADATA_OUTPUT_JSON") \
-            $(printf '${{ inputs.registry }}/${{ inputs.image-name }}@sha256:%s ' *)          
-
-      - name: Inspect image
-        run: |
-          docker buildx imagetools inspect ${{ inputs.registry }}/${{ inputs.image-name }}:${{ steps.meta.outputs.version }}
-          
-      - id: output-image-tag
-        run: |
-          echo "image_tag=${{ steps.meta.outputs.version }}" >> "$GITHUB_OUTPUT"
+  github-runners:
+    if: ${{ inputs.execution-mode == 'github-runners' }}
+    uses: ./.github/workflows/build-and-push-docker-image-github-runners.yml
+    with:
+      ref: ${{ inputs.ref }}
+      image-name: ${{ inputs.image-name }}
+      docker-file: ${{ inputs.docker-file }}
+      docker-context: ${{ inputs.docker-context }}
+      build-args: ${{ inputs.build-args }}
+      labels: ${{ inputs.labels }}
+      tags: ${{ inputs.tags }}
+      image-tag: ${{ inputs.image-tag }}
+      registry: ${{ inputs.registry }}
+      network: ${{ inputs.network }}
+      no-cache: ${{ inputs.no-cache }}
+      cache-from: ${{ inputs.cache-from }}
+      cache-to: ${{ inputs.cache-to }}
+      registry-mirror: ${{ inputs.registry-mirror }}
+      runner-amd64: ubuntu-24.04
+      runner-arm64: ubuntu-24.04-arm
+      runner-merge: ubuntu-latest
+      build-amd64: ${{ inputs.build-amd64 }}
+      build-arm64: ${{ inputs.build-arm64 }}
+    secrets:
+      registry-user: ${{ secrets.registry-user }}
+      registry-password: ${{ secrets.registry-password }}
+      docker-secrets: ${{ secrets.docker-secrets }}

--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,2 @@
-# JetBrains
-
-.idea/
+.DS_Store
+*/.DS_Store


### PR DESCRIPTION
## Summary
- split reusable Docker build workflow into a router plus mode-specific workflows (github-runners and self-hosted-buildkit)
- centralize tag derivation outputs and mode-aware cache/no-cache behavior
- add explicit ARC cache opt-in, debug logging, and update action versions

## Why
Current PR #58 targets a feature base branch; this PR retargets the same branch work to  for direct merge readiness.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added reusable Docker build workflows with selectable execution modes (GitHub runners or self-hosted BuildKit).
  * Exposed configurable inputs for image tagging, caching, per-architecture builds, and registry/login secrets.
  * Improved multi-architecture build flow with per-platform artifacts and consolidated manifest creation; workflow outputs now provide final image tags and metadata.

* **Chores**
  * Updated .gitignore to better handle macOS metadata files.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->