### PR TITLE
Increase command timeout to 30 minutes

### DIFF
--- a/.github/workflows/deploy-docker-compose.yml
+++ b/.github/workflows/deploy-docker-compose.yml
@@ -223,6 +223,7 @@ jobs:
           proxy_username: ${{ vars.DEPLOYMENT_GATEWAY_USER }}
           proxy_key: ${{ secrets.DEPLOYMENT_GATEWAY_SSH_KEY }}
           proxy_port: ${{ vars.DEPLOYMENT_GATEWAY_PORT }}
+          command_timeout: 30m
           script: |
             BASE_PATH="${{ inputs.deployment-base-path }}"
             docker compose -f "$BASE_PATH/${{ steps.extract-basename.outputs.basename }}" --env-file="$BASE_PATH/${{ inputs.env-file-name }}" up --pull=always -d


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Enhanced deployment reliability by improving timeout configuration for Docker deployments.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->