### PR TITLE
Fix GHCR image existence check in deploy workflow

### DIFF
--- a/.github/workflows/deploy-docker-compose.yml
+++ b/.github/workflows/deploy-docker-compose.yml
@@ -45,6 +45,9 @@ on:
 jobs:
   prepare-deploy:
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      packages: read
     outputs:
       image-tag-to-deploy: ${{ steps.retrieve-image-tag.outputs.image-tag-to-deploy }}
     
@@ -80,23 +83,20 @@ jobs:
 
       - name: Check if image exists
         run: |
+          set -euo pipefail
+
           IMAGE_NAME="${{ inputs.main-image-name }}"
           IMAGE_TAG="${{ steps.retrieve-image-tag.outputs.image-tag-to-deploy }}"
+          FULL_IMAGE_REF="ghcr.io/${IMAGE_NAME}:${IMAGE_TAG}"
 
-          echo "Checking for image ${IMAGE_NAME}:${IMAGE_TAG}"
+          echo "Checking for image ${FULL_IMAGE_REF}"
 
-          ENCODED_TOKEN=$(echo -n "${{ secrets.GITHUB_TOKEN }}" | base64)
-          STATUS=$(curl -s -o /dev/null -w "%{http_code}" \
-            -H "Accept: application/vnd.docker.distribution.manifest.v2+json,application/vnd.docker.distribution.manifest.list.v2+json,application/vnd.oci.image.manifest.v1+json,application/vnd.oci.image.index.v1+json" \
-            -H "Authorization: Bearer ${ENCODED_TOKEN}" \
-            "https://ghcr.io/v2/${IMAGE_NAME}/manifests/${IMAGE_TAG}")
-          
-          echo "HTTP status: $STATUS"
-          
-          if [ "$STATUS" -eq "200" ]; then
-            echo "Image ${IMAGE_NAME}:${IMAGE_TAG} exists."
+          echo "${{ secrets.GITHUB_TOKEN }}" | docker login ghcr.io -u "${{ github.actor }}" --password-stdin
+
+          if docker buildx imagetools inspect "${FULL_IMAGE_REF}" >/dev/null 2>&1; then
+            echo "Image ${FULL_IMAGE_REF} exists."
           else
-            echo "Image ${IMAGE_NAME}:${IMAGE_TAG} does not exist."
+            echo "Image ${FULL_IMAGE_REF} does not exist or is not accessible."
             exit 1
           fi
 


### PR DESCRIPTION
## Summary
Fixes the reusable deploy workflow image existence check in `prepare-deploy`.

The previous implementation base64-encoded `GITHUB_TOKEN` and sent it as a Bearer token to GHCR's registry API. This is not a valid GHCR auth flow and can also produce malformed headers when base64 output wraps, which can cause `curl` failures (including exit code 43) before any meaningful HTTP status is evaluated.

## Changes
- Add explicit `prepare-deploy` job permissions:
  - `contents: read`
  - `packages: read`
- Replace manual `curl` check with Docker-native registry auth and manifest lookup:
  - `docker login ghcr.io -u ${{ github.actor }} --password-stdin`
  - `docker buildx imagetools inspect ghcr.io/<image>:<tag>`
- Keep failure behavior unchanged: the job exits non-zero if the image is missing or inaccessible.

## Why this works
- Uses the expected GHCR authentication mechanism with `GITHUB_TOKEN`.
- Avoids hand-crafted auth headers and base64 wrapping pitfalls.
- Validates image/tag existence via manifest inspection in a robust way.

Closes #66

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Enhanced Docker image deployment verification with improved GitHub Actions workflow security settings.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/ls1intum/.github/pull/67?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->